### PR TITLE
feat: new parameters for CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,6 +3133,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stress4844"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap 4.0.25",
  "ethers",
  "ethers-flashbots",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
+edition = "2021"
 name = "stress4844"
 version = "0.1.0"
-edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.0.25", features = ["derive"] }
+chrono = "0.4.23"
+clap = {version = "4.0.25", features = ["derive"]}
 ethers = "1.0.1"
 ethers-flashbots = "0.11.0"
 eyre = "0.6.8"
 fastrand = "1.8.0"
 serde_json = "1.0.89"
-tokio = { version = "1.21.2", features = ["macros"] }
+tokio = {version = "1.21.2", features = ["macros"]}
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing-subscriber = {version = "0.3.16", features = ["env-filter"]}
 url = "2.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
+edition = "2021"
 name = "stress4844"
 version = "0.1.0"
-edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.0.25", features = ["derive"] }
+clap = {version = "4.0.25", features = ["derive"]}
 ethers = "1.0.1"
 ethers-flashbots = "0.11.0"
 eyre = "0.6.8"
 fastrand = "1.8.0"
 serde_json = "1.0.89"
-tokio = { version = "1.21.2", features = ["macros"] }
+tokio = {version = "1.21.2", features = ["macros"]}
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing-subscriber = {version = "0.3.16", features = ["env-filter"]}
 url = "2.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-edition = "2021"
 name = "stress4844"
 version = "0.1.0"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = {version = "4.0.25", features = ["derive"]}
+clap = { version = "4.0.25", features = ["derive"] }
 ethers = "1.0.1"
 ethers-flashbots = "0.11.0"
 eyre = "0.6.8"
 fastrand = "1.8.0"
 serde_json = "1.0.89"
-tokio = {version = "1.21.2", features = ["macros"]}
+tokio = { version = "1.21.2", features = ["macros"] }
 tracing = "0.1.37"
-tracing-subscriber = {version = "0.3.16", features = ["env-filter"]}
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 url = "2.3.1"

--- a/src/bundle_builder.rs
+++ b/src/bundle_builder.rs
@@ -1,0 +1,165 @@
+use rand::{distributions::Standard, Rng};
+
+use ethers::prelude::*;
+use ethers_flashbots::BundleRequest;
+
+use eyre::Result;
+
+/// 1 kilobyte = 1024 bytes
+const KB: usize = 1024;
+
+/// Arbitrarily chosen number to cover for nonce+from+to+gas price size in a serialized
+/// transaction.  TODO: get the actual overhead from the signing, etc. to pack more fully
+const TRIM_BYTES: usize = 300;
+
+#[tracing::instrument(skip_all, name = "construct_bundle")]
+fn construct_tx(
+    chain_id: u64,
+    address: Address,
+    receiver: Address,
+    data_size: usize,
+    gas_price: U256,
+) -> ethers::prelude::TransactionRequest {
+    // Craft the transaction.  data_size is in bytes
+    let blob = generate_random_data(data_size);
+
+    let tx = TransactionRequest::new()
+        .chain_id(chain_id)
+        .value(0)
+        .from(address)
+        .to(receiver)
+        .data(blob)
+        .gas_price(gas_price);
+
+    return tx;
+}
+
+async fn get_signed_tx<M: Middleware>(
+    chain_id: u64,
+    address: H160,
+    receiver: H160,
+    chunk: usize,
+    gas_price: U256,
+    provider: M,
+    nonce: U256,
+) -> Result<Bytes>
+where
+    M::Error: 'static,
+{
+    let mut tx = construct_tx(chain_id, address, receiver, chunk, gas_price);
+    let gas_per_tx = provider.estimate_gas(&tx.clone().into(), None).await?;
+    // tracing::debug!("tx cost {} gas", gas_per_tx);
+    // let blob_len = tx.data.as_ref().map(|x| x.len()).unwrap_or_default();
+    // tracing::debug!("created a {blob_len} byte tx from {chunk} size data");
+
+    // apply nonce and tx gas limit
+    tx.nonce = Some(nonce);
+    tx.gas = Some(gas_per_tx);
+
+    // make into typed tx for the signer
+    let tx = tx.into();
+    let sender = provider.default_sender().unwrap_or_default();
+    let signature = provider.sign_transaction(&tx, sender).await?;
+    // tracing::debug!("sender is {sender} , signature = {signature}");
+    let rlp = tx.rlp_signed(&signature);
+
+    // println!("{}", serde_json::to_string(&tx)?);
+
+    // ad hoc test: submit directly
+    // let tx = provider.send_transaction(tx, None).await?.await?;
+
+    // println!("{}", serde_json::to_string(&tx)?);
+    Ok(rlp)
+}
+
+fn generate_random_data(size: usize) -> Vec<u8> {
+    // size is bytes
+    let blob = rand::thread_rng()
+        .sample_iter(Standard)
+        .take(size) //6 * 1024)
+        .collect::<Vec<u8>>();
+    return blob;
+}
+
+pub async fn construct_bundle<M: Middleware>(
+    chain_id: u64,
+    address: H160,
+    receiver: Address,
+    provider: M,
+    gas_limit: U256,
+    fill_pct: u8,
+    mut nonce: U256,
+    chunk_size: usize,
+    tip_wei: u64,
+) -> Result<BundleRequest>
+where
+    M::Error: 'static,
+{
+    // `CHUNKS_SIZE` Kilobytes per transaction, shave off 300 bytes to leave room for
+    // the other fields to be serialized.
+    let chunk = chunk_size * KB - TRIM_BYTES;
+
+    // For each block, we want `fill_pct` -> we generate N transactions to reach that.
+    let gas_used_per_block = gas_limit * fill_pct / 100;
+    let total_data_size: usize = fill_pct as usize * 2 * 1024 * KB / 100; // block max size is 2MB
+    tracing::debug!(
+        "total data size: {}, gas_used_per_block: {}, blob size (bytes) per tx: {}",
+        total_data_size,
+        gas_used_per_block,
+        chunk
+    );
+
+    //let max_txs_per_block = (gas_used_per_block / gas_per_tx).as_u64();
+    //tracing::debug!(max_txs_per_block);
+
+    let mut current_data_used = TRIM_BYTES;
+    // TODO: Figure out why making a bundle too big fails.
+    let txs_per_block = total_data_size / chunk;
+    // tracing::debug!("txs per block: {}", txs_per_block);
+
+    let default_gas_price = provider.get_gas_price().await?;
+
+    let gas_price = U256::from(tip_wei) + default_gas_price;
+    tracing::debug!("got gas_price {default_gas_price} from provider, increased to {gas_price}");
+
+    // Construct the bundle
+    let mut bundle = BundleRequest::new();
+
+    for _ in 0..txs_per_block {
+        let rlp = get_signed_tx(
+            chain_id, address, receiver, chunk, gas_price, &provider, nonce,
+        )
+        .await?;
+        bundle = bundle.push_transaction(rlp);
+        nonce += 1.into();
+        current_data_used += chunk;
+    }
+
+    // fill the "remainder" of the block with leftover datasize, since we ha
+    let remaining_data = total_data_size - current_data_used - TRIM_BYTES;
+    tracing::debug!("signed {txs_per_block} transactions of {chunk} size each, filling remainder {remaining_data}");
+    let last_rlp = get_signed_tx(
+        chain_id,
+        address,
+        receiver,
+        remaining_data,
+        gas_price,
+        &provider,
+        nonce,
+    )
+    .await?;
+    bundle = bundle.push_transaction(last_rlp);
+
+    // let payment = TransactionRequest::new()
+    //     .to(COINBASE_PAYER_ADDR.parse::<Address>()?)
+    //     .nonce(nonce)
+    //     .gas(30000)
+    //     .gas_price(gas_price)
+    //     .value(payment)
+    //     .into();
+    // let signature = provider.signer().sign_transaction(&payment).await?;
+    // let rlp = tx.rlp_signed(&signature);
+    // bundle = bundle.push_transaction(rlp);
+
+    Ok(bundle)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,11 +39,9 @@ struct Opts {
     #[arg(long, short)]
     bundle_signer: String,
 
-    #[arg(default_value = "14567759743", long, short)]
-    gas_price: U256,
-
-    #[arg(default_value = "6000000000", long)]
-    tip_wei: u64,
+    #[arg(default_value = "6000000000", long)] // default "tip" is 6gwei.
+    tip_wei: u64, // have noticed that on goerli, inclusion seems to be pretty
+                  // insensitive to the bribe/tip amount
 }
 
 fn http_provider(s: &str) -> Result<String, String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,17 @@
-// Eth libs
-use ethers::prelude::{signer::SignerMiddleware, *};
-use ethers_flashbots::{BundleRequest, FlashbotsMiddleware};
-
 // CLI
 use clap::Parser;
 use eyre::Result;
 use tracing_subscriber::{filter::EnvFilter, prelude::*};
 
 // Misc
-use rand::{distributions::Standard, Rng};
-use std::{sync::Arc, time::Duration};
+use ethers::prelude::*;
+use ethers_flashbots::FlashbotsMiddleware;
+use std::sync::Arc;
+use std::time::Duration;
 use url::Url;
+
+// local utils
+mod bundle_builder;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -18,7 +19,7 @@ struct Opts {
     /// The number of blocks to run the stress test for
     blocks: usize,
 
-    #[arg(default_value = "100", long, short, value_parser = clap::value_parser!(u8).range(1..=100))]
+    #[arg(default_value = "99", long, short, value_parser = clap::value_parser!(u8).range(1..=100))]
     /// What % of the block to fill (0-100).
     fill_pct: u8,
 
@@ -38,15 +39,11 @@ struct Opts {
     #[arg(long, short)]
     bundle_signer: String,
 
-    #[arg(default_value = "100", long, short)]
+    #[arg(default_value = "14567759743", long, short)]
     gas_price: U256,
 
-    #[arg(long, short, value_parser = from_dec_str)]
-    payment: U256,
-}
-
-fn from_dec_str(s: &str) -> Result<U256, String> {
-    U256::from_dec_str(s).map_err(|e| e.to_string())
+    #[arg(default_value = "6000000000", long)]
+    tip_wei: u64,
 }
 
 fn http_provider(s: &str) -> Result<String, String> {
@@ -57,26 +54,6 @@ fn http_provider(s: &str) -> Result<String, String> {
     }
 }
 
-// From: https://github.com/ethereum/go-ethereum/blob/c2e0abce2eedc1ba2a1b32c46fd07ef18a25354a/core/txpool/txpool.go#L44-L55
-/// `TX_SLOT_SIZE` is used to calculate how many data slots a single transaction
-/// takes up based on its size. The slots are used as DoS protection, ensuring
-/// that validating a new transaction remains a constant operation (in reality
-/// O(maxslots), where max slots are 4 currently).
-const _TX_SLOT_SIZE: usize = 32 * 1024;
-
-/// txMaxSize is the maximum size a single transaction can have. This field has
-/// non-trivial consequences: larger transactions are significantly harder and
-/// more expensive to propagate; larger transactions also take more resources
-/// to validate whether they fit into the pool or not.
-const _TX_MAX_SIZE: usize = 4 * _TX_SLOT_SIZE; // 128KB
-
-/// 1 kilobyte = 1024 bytes
-const KB: usize = 1024;
-
-/// Arbitrarily chosen number to cover for nonce+from+to+gas price size in a serialized
-/// transaction
-const TRIM_BYTES: usize = 500;
-
 /// Address of the following contract to allow for easy coinbase payments on Goerli.
 ///
 /// contract CoinbasePayer {
@@ -84,97 +61,93 @@ const TRIM_BYTES: usize = 500;
 ///         payable(address(block.coinbase)).transfer(msg.value);
 ///     }
 /// }
-const COINBASE_PAYER_ADDR: &str = "0x060d6635bb76c71871f97C12f10Fa20BD8e87eC0";
+// const COINBASE_PAYER_ADDR: &str = "0x060d6635bb76c71871f97C12f10Fa20BD8e87eC0";
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     let opts = Opts::parse();
-    let payment = opts.payment;
+    let interval = Duration::from_secs(1);
+    let rpc_url = opts.rpc_url;
+    let tx_signer = opts.tx_signer.strip_prefix("0x").unwrap_or(&opts.tx_signer);
+    let bundle_signer = opts
+        .bundle_signer
+        .strip_prefix("0x")
+        .unwrap_or(&opts.bundle_signer);
+    let mut landed = 0;
+    let blocks_to_land = opts.blocks;
+    let fill_pct = opts.fill_pct; // how much of the full 2MB payload to take up with calldata
+    let tip_wei = opts.tip_wei; // how much to overpay on gas, in percentage points
+
+    let chunk_size = opts.chunk_size;
+    //let chunk_size = ethers::prelude::U256::from(opts.chunk_size); // for example, 384, 512, etc.
 
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer())
         .with(EnvFilter::new("stress4844=trace"))
         .init();
 
-    let interval = Duration::from_secs(1);
-    let provider = Arc::new(Provider::try_from(opts.rpc_url)?.interval(interval));
-    let signer = opts
-        .tx_signer
-        .strip_prefix("0x")
-        .unwrap_or(&opts.tx_signer)
-        .parse::<LocalWallet>()?;
+    let bundle_signer = bundle_signer.parse::<LocalWallet>()?;
 
-    let bundle_signer = opts
-        .bundle_signer
-        .strip_prefix("0x")
-        .unwrap_or(&opts.bundle_signer)
-        .parse::<LocalWallet>()?;
+    let provider: Arc<Provider<Http>> =
+        Arc::new(Provider::<Http>::try_from(rpc_url)?.interval(interval));
+
+    let signer = tx_signer.parse::<LocalWallet>()?;
 
     let bundle_middleware = FlashbotsMiddleware::new(
         provider.clone(),
-        Url::parse("https://relay-goerli.flashbots.net/")?,
+        Url::parse("https://relay-goerli.flashbots.net/")?, // TODO: make configurable
         bundle_signer,
     );
 
     let address = signer.address();
     let balance = provider.get_balance(address, None).await?;
-    let block = provider
-        .get_block(BlockNumber::Latest)
-        .await?
-        .expect("could not get latest block");
-    let nonce = provider
-        .get_transaction_count(address, Some(BlockNumber::Pending.into()))
-        .await?;
 
     tracing::info!(
-        "starting benchmark from {:?} (balance: {} ETH, nonce: {})",
+        "starting benchmark from {:?} (balance: {} ETH)",
         address,
         ethers::core::utils::format_units(balance, "eth")?,
-        nonce
     );
-    tracing::info!("builder payment {}", payment);
-    tracing::debug!("block gas limit: {} gas", block.gas_limit);
     let provider =
         Arc::new(SignerMiddleware::new_with_provider_chain(bundle_middleware, signer).await?);
     let chain_id = provider.signer().chain_id();
 
+    let mut nonce = provider
+        .get_transaction_count(address, Some(BlockNumber::Pending.into()))
+        .await?;
+    tracing::debug!("current nonce: {}", nonce);
     // TODO: Do we want this to be different per transaction?
     let receiver: Address = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".parse()?;
 
-    // `CHUNKS_SIZE` Kilobytes per transaction, shave off 500 bytes to leave room for
-    // the other fields to be serialized.
-    let chunk = opts.chunk_size * KB - TRIM_BYTES;
+    let block = provider
+        .get_block(BlockNumber::Latest)
+        .await?
+        .expect("could not get latest block");
 
-    // Sample junk data for the blob.
-    let blob = rand::thread_rng()
-        .sample_iter(Standard)
-        .take(chunk)
-        .collect::<Vec<u8>>();
-
-    // Craft the transaction.
-    let tx = TransactionRequest::new()
-        .chain_id(chain_id)
-        .value(0)
-        .from(address)
-        .to(receiver)
-        .data(blob)
-        .gas_price(opts.gas_price);
-
-    let mut bundle = construct_bundle(
+    let mut bundle = bundle_builder::construct_bundle(
+        chain_id,
+        address,
+        receiver,
         provider.clone(),
-        &tx,
         block.gas_limit,
-        opts.fill_pct,
+        fill_pct,
         nonce,
-        payment,
+        chunk_size,
+        tip_wei,
     )
     .await?;
+    // should always be 30 million:
+    // tracing::debug!("block gas limit: {} gas", block.gas_limit);
 
     // on every block try to get the bundle in
     let mut block_sub = provider.watch_blocks().await?;
     tracing::info!("subscribed to blocks - waiting for next");
-    while block_sub.next().await.is_some() {
+    while block_sub.next().await.is_some() && landed <= blocks_to_land {
         let block_number = provider.get_block_number().await?;
+        let block = provider
+            .get_block(BlockNumber::Latest)
+            .await?
+            .expect("could not get latest block");
+        //tracing::debug!("block gas limit: {} gas", block.gas_limit);
 
         let span = tracing::trace_span!("submit-bundle", block = block_number.as_u64());
         let _enter = span.enter();
@@ -189,90 +162,33 @@ async fn main() -> eyre::Result<()> {
         match pending_bundle.await {
             Ok(bundle_hash) => {
                 // TODO: Can we log more info from the Flashbots API?
-                tracing::info!("bundle included! hash: {:?}", bundle_hash);
-                let nonce = provider
-                    .get_transaction_count(address, Some(BlockNumber::Pending.into()))
-                    .await?;
-                tracing::debug!("signing new bundle for next block (new nonce: {})", nonce);
-                bundle = construct_bundle(
-                    provider.clone(),
-                    &tx,
-                    block.gas_limit,
-                    opts.fill_pct,
-                    nonce,
-                    payment,
-                )
-                .await?;
+                tracing::info!("bundle #{} included! hash: {:?}", landed, bundle_hash);
+
+                landed += 1; // actually check if we landed it?
             }
             Err(err) => {
-                tracing::error!("{}. Retrying.", err);
+                tracing::error!("{}. did not land bundle, retrying.", err);
             }
         }
+        nonce = provider
+            .get_transaction_count(address, Some(BlockNumber::Pending.into()))
+            .await?; // TODO: keep track of nonce ourselves?
+        tracing::debug!("signing new bundle for next block (new nonce: {})", nonce);
+        bundle = bundle_builder::construct_bundle(
+            chain_id,
+            address,
+            receiver,
+            provider.clone(),
+            block.gas_limit,
+            fill_pct,
+            nonce,
+            chunk_size,
+            tip_wei,
+        )
+        .await?;
     }
 
     tracing::debug!("Done! End Block: {}", provider.get_block_number().await?);
 
     Ok(())
-}
-
-#[tracing::instrument(skip_all, name = "construct_bundle")]
-async fn construct_bundle<M: Middleware + 'static>(
-    provider: Arc<SignerMiddleware<M, LocalWallet>>,
-    tx: &TransactionRequest,
-    gas_limit: U256,
-    fill_pct: u8,
-    mut nonce: U256,
-    payment: U256,
-) -> Result<BundleRequest> {
-    let gas_per_tx = provider.estimate_gas(&tx.clone().into(), None).await?;
-    tracing::debug!("tx cost {} gas", gas_per_tx);
-
-    // For each block, we want `fill_pct` -> we generate N transactions to reach that.
-    let gas_used_per_block = gas_limit * fill_pct / 100;
-
-    let max_txs_per_block = (gas_used_per_block / gas_per_tx).as_u64();
-    tracing::debug!(max_txs_per_block);
-
-    let txs_per_block = max_txs_per_block;
-
-    eyre::ensure!(
-        max_txs_per_block >= txs_per_block,
-        "tried to submit more transactions than can fit in a block"
-    );
-    let blob_len = tx.data.as_ref().map(|x| x.len()).unwrap_or_default();
-    tracing::debug!("submitting {txs_per_block} {blob_len} byte txs per block",);
-
-    let gas_price = provider.get_gas_price().await?;
-
-    // Construct the bundle
-    let mut bundle_gas = U256::zero();
-    let mut bundle = BundleRequest::new();
-    for _ in 0..txs_per_block {
-        let mut tx = tx.clone();
-
-        // increment the nonce and apply it
-        tx.nonce = Some(nonce);
-        nonce += 1.into();
-        tracing::trace!("signed nonce {}", nonce.as_u64());
-        tx.gas = Some(gas_per_tx);
-        tx.gas_price = Some(ethers::utils::parse_units(1, "gwei")?);
-        bundle_gas += gas_per_tx;
-
-        // make into typed tx for the signer
-        let tx = tx.into();
-        let signature = provider.signer().sign_transaction(&tx).await?;
-        let rlp = tx.rlp_signed(&signature);
-        bundle = bundle.push_transaction(rlp);
-    }
-
-    tracing::debug!(
-        "signed {} transactions, bundle gas {}",
-        txs_per_block,
-        bundle_gas
-    );
-
-    let serialized_bundle = serde_json::to_string(&bundle)?;
-    tracing::debug!("bundle size: {} bytes", serialized_bundle.len());
-
-    Ok(bundle)
 }


### PR DESCRIPTION
modified the CLI to be a little more flexible with regards to tuning bundle parameters.

objective: land as many "large" bundles as consecutively as possible.

example usage:

`cargo r -- --rpc-url $ETH_RPC_URL --tx-signer $SIGNER --bundle-signer $BUNDLE  --chunk-size 512  --fill-pct 80 --tip-wei $(cast --to-unit 10gwei) --blocks 8`